### PR TITLE
Feature/basic pawn movement

### DIFF
--- a/Chess/include/board/ChessBoard.h
+++ b/Chess/include/board/ChessBoard.h
@@ -27,7 +27,6 @@ public:
     int checkMovement(const std::pair<int, int>& from, const std::pair<int, int>& to, bool isWhiteTurn) const;
     void movePiece(const std::pair<int, int>& from, const std::pair<int, int>& to);
     void setupPieceAt(char pieceChar, const std::pair<int, int>& pos);
-    void printBoard() const;
 
 private:
     std::vector<std::vector<std::unique_ptr<ChessPiece>>> m_board;

--- a/Chess/include/pieces/Pawn.h
+++ b/Chess/include/pieces/Pawn.h
@@ -1,0 +1,18 @@
+
+#pragma once
+#include "ChessPiece.h"
+
+class Pawn : public ChessPiece {
+
+public:
+
+    Pawn(bool isWhite, char pieceType, const std::pair<int, int>& pos);
+
+    // Delete copy constructor and assignment
+    Pawn(const Pawn&) = delete;
+    Pawn& operator=(const Pawn&) = delete;
+
+    // Add move constructor and assignment
+    Pawn(Pawn&&) noexcept = default;
+    Pawn& operator=(Pawn&&) noexcept = default;
+};

--- a/Chess/include/strategies/KingMoveStrategy.h
+++ b/Chess/include/strategies/KingMoveStrategy.h
@@ -6,4 +6,14 @@ public:
     int checkMovement(const ChessBoard& board,
                       const std::pair<int, int>& from,
                       const std::pair<int, int>& to) const override;
+
+private:
+
+    // Note: Function declarations for future Castling implementations
+    // bool isCastlingMove(const ChessBoard& board, bool isWhite,
+    //                     const std::pair<int, int>& from, 
+    //                     const std::pair<int, int>& to) const;
+    // bool canCastle(const ChessBoard& board, bool isWhite,
+    //                const std::pair<int, int>& from, 
+    //                const std::pair<int, int>& to) const;
 };

--- a/Chess/include/strategies/PawnMoveStrategy.h
+++ b/Chess/include/strategies/PawnMoveStrategy.h
@@ -25,9 +25,9 @@ private:
                               const std::pair<int, int>& from,
                               const std::pair<int, int>& to) const;
 
-    // Note: Function declarations for future EnPassant and Promotion implementations
-    // bool canCaptureEnPassant(const ChessBoard& board, bool isWhite,
-    //                          const std::pair<int, int>& from, 
-    //                          const std::pair<int, int>& to) const;
-    // bool isPromotionMove(bool isWhite, const std::pair<int, int>& to) const;
+    /* Note: Function declarations for future EnPassant and Promotion implementations
+     bool canCaptureEnPassant(const ChessBoard& board, bool isWhite,
+                              const std::pair<int, int>& from, 
+                              const std::pair<int, int>& to) const;
+     bool isPromotionMove(bool isWhite, const std::pair<int, int>& to) const;*/
 };

--- a/Chess/include/strategies/PawnMoveStrategy.h
+++ b/Chess/include/strategies/PawnMoveStrategy.h
@@ -1,0 +1,33 @@
+
+#pragma once
+#include "strategies/MoveStrategy.h"
+
+class PawnMoveStrategy : public MoveStrategy {
+
+public:
+    int checkMovement(const ChessBoard& board,
+                      const std::pair<int, int>& from,
+                      const std::pair<int, int>& to) const override;
+
+private:
+    bool canMoveForward(const ChessBoard& board,
+                        bool isWhite,
+                        const std::pair<int, int>& from,
+                        const std::pair<int, int>& to) const;
+
+    bool canMoveTwoSquares(const ChessBoard& board,
+                           bool isWhite,
+                           const std::pair<int, int>& from,
+                           const std::pair<int, int>& to) const;
+
+    bool canCaptureDiagonally(const ChessBoard& board,
+                              bool isWhite,
+                              const std::pair<int, int>& from,
+                              const std::pair<int, int>& to) const;
+
+    // Note: Function declarations for future EnPassant and Promotion implementations
+    // bool canCaptureEnPassant(const ChessBoard& board, bool isWhite,
+    //                          const std::pair<int, int>& from, 
+    //                          const std::pair<int, int>& to) const;
+    // bool isPromotionMove(bool isWhite, const std::pair<int, int>& to) const;
+};

--- a/Chess/src/CMakeLists.txt
+++ b/Chess/src/CMakeLists.txt
@@ -9,6 +9,7 @@
     "${CMAKE_CURRENT_SOURCE_DIR}/pieces/Bishop.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/pieces/Queen.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/pieces/Knight.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/pieces/Pawn.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/factories/PieceFactory.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/factories/MoveStrategyFactory.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/strategies/RookMoveStrategy.cpp"
@@ -16,4 +17,5 @@
     "${CMAKE_CURRENT_SOURCE_DIR}/strategies/KnightMoveStrategy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/strategies/KingMoveStrategy.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/strategies/QueenMoveStrategy.cpp"
+    "${CMAKE_CURRENT_SOURCE_DIR}/strategies/PawnMoveStrategy.cpp"
 )

--- a/Chess/src/board/ChessBoard.cpp
+++ b/Chess/src/board/ChessBoard.cpp
@@ -57,9 +57,11 @@ const ChessPiece* ChessBoard::getPieceAt(int row, int col) const {
  * @param isWhiteTurn Indicates whether it's white's turn.
  * @return Status code indicating the result of the move.
  */
-int ChessBoard::checkMovement(const std::pair<int, int>& from, const std::pair<int, int>& to, bool isWhiteTurn) const {
+int ChessBoard::checkMovement(const std::pair<int, int>& from, 
+                              const std::pair<int, int>& to, 
+                              bool isWhiteTurn) const {
 
-    //If conversion failed - treat as "no piece at source" - not need to happen cause we check in Chess class
+    //If conversion failed - treat as code 11 - not need to happen cause we check in Chess class
     if (from.first == -1 || to.first == -1) {
 
         return MOVE_NO_PIECE_IN_SOURCE;  // Code 11

--- a/Chess/src/board/ChessBoard.cpp
+++ b/Chess/src/board/ChessBoard.cpp
@@ -128,19 +128,3 @@ void ChessBoard::setupPieceAt(char pieceChar, const std::pair<int, int>& pos) {
     m_board[pos.first][pos.second] = PieceFactory::createPiece(pieceChar, pos);
 }
 //------------------------------------------------------------------------
-/**
- * Prints the current board state to the console (for debugging).
- */
-/*
-void ChessBoard::printBoard() const {
-    for (int i = 0; i < 8; ++i) {
-        for (int j = 0; j < 8; ++j) {
-            if (m_board[i][j])
-                std::cout << m_board[i][j]->getPieceType() << " ";
-            else
-                std::cout << ". ";
-        }
-        std::cout << "\n";
-    }
-}
-*/

--- a/Chess/src/board/GameManager.cpp
+++ b/Chess/src/board/GameManager.cpp
@@ -49,7 +49,7 @@ std::pair<int, int> GameManager::convertPosition(const std::string& pos) const {
  */
 int GameManager::checkMovement(const std::string& move) {
     
-    // if invalid format - treat as "no piece at source" - not need to happen cause we check in Chess class
+    //Invalid format - treat as "no piece at source" - not need to happen cause we check in Chess class
     if (move.size() != 4) {
         return MOVE_NO_PIECE_IN_SOURCE; 
     }

--- a/Chess/src/board/GameManager.cpp
+++ b/Chess/src/board/GameManager.cpp
@@ -49,7 +49,7 @@ std::pair<int, int> GameManager::convertPosition(const std::string& pos) const {
  */
 int GameManager::checkMovement(const std::string& move) {
     
-    //Invalid format - treat as "no piece at source" - not need to happen cause we check in Chess class
+    //Invalid format - treat as code 11 - not need to happen cause we check in Chess class
     if (move.size() != 4) {
         return MOVE_NO_PIECE_IN_SOURCE; 
     }

--- a/Chess/src/factories/MoveStrategyFactory.cpp
+++ b/Chess/src/factories/MoveStrategyFactory.cpp
@@ -7,6 +7,7 @@
 #include "strategies/KnightMoveStrategy.h"
 #include "strategies/KingMoveStrategy.h"
 #include "strategies/QueenMoveStrategy.h"
+#include "strategies/PawnMoveStrategy.h"
 
 //------------------------------------------------------------------------
 /**
@@ -29,6 +30,7 @@ void MoveStrategyFactory::initialize() {
     auto knightStrategy = std::make_shared<KnightMoveStrategy>();
     auto kingStrategy = std::make_shared<KingMoveStrategy>();
     auto queenStrategy = std::make_shared<QueenMoveStrategy>(rookStrategy, bishopStrategy);
+    auto pawnStrategy = std::make_shared<PawnMoveStrategy>();
 
     // Register all piece strategies
     m_strategies['R'] = rookStrategy;
@@ -45,6 +47,9 @@ void MoveStrategyFactory::initialize() {
 
     m_strategies['K'] = kingStrategy;
     m_strategies['k'] = kingStrategy;
+
+    m_strategies['P'] = pawnStrategy;
+    m_strategies['p'] = pawnStrategy;
 }
 //------------------------------------------------------------------------
 /**

--- a/Chess/src/factories/PieceFactory.cpp
+++ b/Chess/src/factories/PieceFactory.cpp
@@ -6,7 +6,8 @@
 #include "pieces/King.h"
 #include "pieces/Bishop.h" 
 #include "pieces/Queen.h" 
-#include "pieces/Knight.h" // Include other pieces when added
+#include "pieces/Knight.h" 
+#include "pieces/Pawn.h"
 
 
 //------------------------------------------------------------------------
@@ -67,7 +68,12 @@ void PieceFactory::initialize() {
         return std::make_unique<Knight>(false, 'n', pos);
         };
 
-    // Add other pieces 
+    m_pieceCreators['P'] = [](bool isWhite, char symbol, const std::pair<int, int>& pos) {
+        return std::make_unique<Pawn>(true, 'P', pos);
+        };
+    m_pieceCreators['p'] = [](bool isWhite, char symbol, const std::pair<int, int>& pos) {
+        return std::make_unique<Pawn>(false, 'p', pos);
+        };
 
 }
 

--- a/Chess/src/main.cpp
+++ b/Chess/src/main.cpp
@@ -4,8 +4,8 @@
 
 int main()
 {
-	//string board = "RNBQKBNRPPPPPPPP################################pppppppprnbqkbnr"; 
-	string board = "RNBQKBNR################################################rnbqkbnr";
+	string board = "RNBQKBNRPPPPPPPP################################pppppppprnbqkbnr"; 
+	//string board = "RNBQKBNR################################################rnbqkbnr";
 	Chess a(board);
 	GameManager gameManager(board);   //create the manger of the game
 

--- a/Chess/src/pieces/ChessPiece.cpp
+++ b/Chess/src/pieces/ChessPiece.cpp
@@ -5,6 +5,13 @@
 #include "GameConstants.h"
 
 //------------------------------------------------------------------------
+/**
+ * Constructor for a chess piece.
+ *
+ * @param isWhite   True if the piece is white, false if black.
+ * @param pieceType Character representing the type of the piece (e.g., 'K' for King).
+ * @param pos       Initial position on the board.
+ */
 ChessPiece::ChessPiece(bool isWhite, char pieceType, const std::pair<int, int>& pos)
     : m_isWhite(isWhite), m_pieceType(pieceType), m_position(pos) {
 
@@ -12,30 +19,56 @@ ChessPiece::ChessPiece(bool isWhite, char pieceType, const std::pair<int, int>& 
 };
 
 //------------------------------------------------------------------------
+/**
+ * Sets the piece's new position.
+ *
+ * @param newPos New coordinates on the board.
+ */
 void ChessPiece::setPosition(const std::pair<int, int>& newPos) {
     m_position = newPos;
 }
 
 //------------------------------------------------------------------------
+/**
+ * Returns the current position of the piece.
+ *
+ * @return Pair of integers representing the row and column.
+ */
 std::pair<int, int> ChessPiece::getPosition() const {
     return m_position;
 }
 
 //------------------------------------------------------------------------
+/**
+ * Returns the type of the piece.
+ *
+ * @return Character representing the type (e.g., 'P' for Pawn, 'K' for King).
+ */
 char ChessPiece::getPieceType() const {
     return m_pieceType;
 }
 
 //------------------------------------------------------------------------
+/**
+ * Returns the color of the piece.
+ *
+ * @return True if the piece is white, false if black.
+ */
 bool ChessPiece::getColor() const {
     return m_isWhite;
 }
 //------------------------------------------------------------------------
-
+/**
+ * Validates whether the move to a new position is allowed for this piece.
+ * Delegates the validation to the appropriate movement strategy.
+ *
+ * @param board   The current state of the chess board.
+ * @param newPos  The position to move to.
+ * @return MOVE_SUCCESS if the move is valid, otherwise MOVE_INVALID_OR_BLOCKED.
+ */
 int ChessPiece::checkMovement(const ChessBoard& board, const std::pair<int, int>& newPos) const {
    
     if (!m_moveStrategy) {
-       
         return MOVE_INVALID_OR_BLOCKED; // No strategy defined - fallback for any unexpected or malformed input
     }
 

--- a/Chess/src/pieces/Pawn.cpp
+++ b/Chess/src/pieces/Pawn.cpp
@@ -1,0 +1,6 @@
+
+#include "pieces/Pawn.h"
+
+//------------------------------------------------------------------------
+Pawn::Pawn(bool isWhite, char pieceType, const std::pair<int, int>& pos)
+    : ChessPiece(isWhite, pieceType, pos) {}

--- a/Chess/src/strategies/KingMoveStrategy.cpp
+++ b/Chess/src/strategies/KingMoveStrategy.cpp
@@ -27,6 +27,24 @@ int KingMoveStrategy::checkMovement(const ChessBoard& board,
 
     // Kings can only move one square in any direction
     if (rowDiff > 1 || colDiff > 1) {
+
+       /* Note: Castling implementation would be checked here
+        To implement castling, we would need:
+        1. Check if king has moved before (requires move tracking)
+        2. Check if rook has moved before (requires move tracking)
+        3. Check if path between king and rook is clear
+        4. Check if king is in check or would pass through check
+        5. Handle the king moving two squares and the rook jumping over
+       
+        For example:
+        if (isCastlingMove(board, from, to)) {
+            if (canCastle(board, from, to)) {
+                // Would need to move the rook as well in *Chess* class
+                return MOVE_CASTLING; // New constant code response
+            }
+        }
+       */
+
         return MOVE_INVALID_OR_BLOCKED;
     }
 
@@ -35,8 +53,5 @@ int KingMoveStrategy::checkMovement(const ChessBoard& board,
         return MOVE_INVALID_OR_BLOCKED;
     }
 
-    // Castling would be handled here if implementing that feature
-
     return MOVE_SUCCESS;
-
 }

--- a/Chess/src/strategies/PawnMoveStrategy.cpp
+++ b/Chess/src/strategies/PawnMoveStrategy.cpp
@@ -4,10 +4,19 @@
 
 
 //------------------------------------------------------------------------
+/**
+ * Checks if a pawn move is valid.
+ * Supports forward movement, diagonal captures, and placeholders for promotion and en passant.
+ *
+ * @param board The chess board.
+ * @param from  Current position of the pawn.
+ * @param to    Target position to move to.
+ * @return MOVE_SUCCESS if the move is valid, otherwise MOVE_INVALID_OR_BLOCKED.
+ */
 int PawnMoveStrategy::checkMovement(const ChessBoard& board,
+                                    const std::pair<int, int>& from,
+                                    const std::pair<int, int>& to) const {
     
-    const std::pair<int, int>& from,
-    const std::pair<int, int>& to) const {
     const ChessPiece* piece = board.getPieceAt(from.first, from.second);
     if (!piece) {
         return MOVE_INVALID_OR_BLOCKED;
@@ -18,15 +27,16 @@ int PawnMoveStrategy::checkMovement(const ChessBoard& board,
 
     // Forward movement with no capture
     if (colDiff == 0) {
-        if (canMoveForward(board, isWhite, from, to) ||
-            canMoveTwoSquares(board, isWhite, from, to)) {
+        if (canMoveForward(board, isWhite, from, to) || canMoveTwoSquares(board, isWhite, from, to)) {
 
-            // Note: Pawn promotion detection could be implemented here, but since the Chess class
-            // cannot be modified, the promoted piece would not be visually represented on the board.
-            // A full implementation would require changes to the Chess class to update the displayed piece.
-            // if ((isWhite && to.first == 7) || (!isWhite && to.first == 0)) {
-            //     // Promotion logic would go here
-            // }
+            /*
+             Note: Pawn *promotion* detection could be implemented here, but since the Chess class
+             cannot be modified, the promoted piece would not be visually represented on the board.
+             -> A full implementation would require changes to the Chess class to update the displayed piece.
+             if ((isWhite && to.first == 7) || (!isWhite && to.first == 0)) {
+                 // Promotion logic here
+            }
+            */
 
             return MOVE_SUCCESS;
         }
@@ -35,64 +45,103 @@ int PawnMoveStrategy::checkMovement(const ChessBoard& board,
     else if (colDiff == 1) {
         if (canCaptureDiagonally(board, isWhite, from, to)) {
 
-            // Note: Similar promotion check would be needed here for diagonal captures
-            // if ((isWhite && to.first == 7) || (!isWhite && to.first == 0)) {
-            //     // Promotion logic would go here
-            // }
+            /*
+             Note: Similar promotion check would be needed here for diagonal captures
+             if ((isWhite && to.first == 7) || (!isWhite && to.first == 0)) {
+                 // Promotion logic would go here
+             }
+            */
 
             return MOVE_SUCCESS;
         }
 
-        // Note: En passant capture could be implemented here, but would require tracking the last move
-        // in the ChessBoard class and updating the Chess display to show the captured pawn is removed.
-        // if (canCaptureEnPassant(board, isWhite, from, to)) {
-        //     return MOVE_SUCCESS;
-        // }
+        /*
+         Note: *En passant* capture could be implemented here, and would require tracking the last move
+         in the ChessBoard class and updating the Chess display(cannot modified) to show the captured pawn is removed.
+         if (canCaptureEnPassant(board, isWhite, from, to)) {
+             return MOVE_SUCCESS;
+         }
+        */
     }
 
     return MOVE_INVALID_OR_BLOCKED;
 }
 
 //------------------------------------------------------------------------
+/**
+ * Checks if a pawn can move forward one square.
+ *
+ * @param board      The chess board.
+ * @param isWhite    True if the pawn is white.
+ * @param from       Current position.
+ * @param to         Target position.
+ * @return true if move is valid.
+ */
 bool PawnMoveStrategy::canMoveForward(const ChessBoard& board,
-    bool isWhite,
-    const std::pair<int, int>& from,
-    const std::pair<int, int>& to) const {
+                                      bool isWhite,
+                                      const std::pair<int, int>& from,
+                                      const std::pair<int, int>& to) const {
+    
     int forwardDirection = isWhite ? 1 : -1;
     int rowDiff = to.first - from.first;
 
     // One square forward
-    if (rowDiff == forwardDirection && to.second == from.second &&
+    if (rowDiff == forwardDirection && 
+        to.second == from.second && 
         !board.isOccupied(to.first, to.second)) {
+       
         return true;
     }
     return false;
 }
 
 //------------------------------------------------------------------------
+/**
+ * Checks if a pawn can move forward two squares from its initial position.
+ *
+ * @param board      The chess board.
+ * @param isWhite    True if the pawn is white.
+ * @param from       Current position.
+ * @param to         Target position.
+ * @return true if two-square move is valid.
+ */
 bool PawnMoveStrategy::canMoveTwoSquares(const ChessBoard& board,
-    bool isWhite,
-    const std::pair<int, int>& from,
-    const std::pair<int, int>& to) const {
+                                         bool isWhite,
+                                         const std::pair<int, int>& from,
+                                         const std::pair<int, int>& to) const {
+    
     int forwardDirection = isWhite ? 1 : -1;
     int rowDiff = to.first - from.first;
-
-    // Two squares from starting position
+  
     bool inStartPosition = (isWhite && from.first == 1) || (!isWhite && from.first == 6);
 
-    if (rowDiff == 2 * forwardDirection && to.second == from.second && inStartPosition) {
+    // Two squares from starting position
+    if (rowDiff == 2 * forwardDirection &&
+        to.second == from.second &&
+        inStartPosition) {
+        
         int midRow = from.first + forwardDirection;
-        return !board.isOccupied(midRow, from.second) &&
-            !board.isOccupied(to.first, to.second);
+        return (!board.isOccupied(midRow, from.second) &&
+                !board.isOccupied(to.first, to.second)     );
     }
     return false;
 }
 
 //------------------------------------------------------------------------
+/**
+ * Checks if a pawn can capture a piece diagonally.
+ *
+ * @param board      The chess board.
+ * @param isWhite    True if the pawn is white.
+ * @param from       Current position.
+ * @param to         Target capture position.
+ * @return true if diagonal capture is allowed.
+ */
 bool PawnMoveStrategy::canCaptureDiagonally(const ChessBoard& board,
-    bool isWhite,
-    const std::pair<int, int>& from,
-    const std::pair<int, int>& to) const {
+                                            bool isWhite,
+                                            const std::pair<int, int>& from,
+                                            const std::pair<int, int>& to) const {
+   
     int forwardDirection = isWhite ? 1 : -1;
     int rowDiff = to.first - from.first;
 
@@ -101,7 +150,7 @@ bool PawnMoveStrategy::canCaptureDiagonally(const ChessBoard& board,
         board.isOccupied(to.first, to.second)) {
 
         const ChessPiece* targetPiece = board.getPieceAt(to.first, to.second);
-        return targetPiece && targetPiece->getColor() != isWhite;
+        return (targetPiece && targetPiece->getColor() != isWhite);
     }
     return false;
 }

--- a/Chess/src/strategies/PawnMoveStrategy.cpp
+++ b/Chess/src/strategies/PawnMoveStrategy.cpp
@@ -1,0 +1,126 @@
+#include "strategies/PawnMoveStrategy.h"
+#include "board/ChessBoard.h"
+#include <cstdlib> 
+
+
+//------------------------------------------------------------------------
+int PawnMoveStrategy::checkMovement(const ChessBoard& board,
+    
+    const std::pair<int, int>& from,
+    const std::pair<int, int>& to) const {
+    const ChessPiece* piece = board.getPieceAt(from.first, from.second);
+    if (!piece) {
+        return MOVE_INVALID_OR_BLOCKED;
+    }
+
+    bool isWhite = piece->getColor();
+    int colDiff = std::abs(to.second - from.second);
+
+    // Forward movement with no capture
+    if (colDiff == 0) {
+        if (canMoveForward(board, isWhite, from, to) ||
+            canMoveTwoSquares(board, isWhite, from, to)) {
+
+            // Note: Pawn promotion detection could be implemented here, but since the Chess class
+            // cannot be modified, the promoted piece would not be visually represented on the board.
+            // A full implementation would require changes to the Chess class to update the displayed piece.
+            // if ((isWhite && to.first == 7) || (!isWhite && to.first == 0)) {
+            //     // Promotion logic would go here
+            // }
+
+            return MOVE_SUCCESS;
+        }
+    }
+    // Diagonal capture
+    else if (colDiff == 1) {
+        if (canCaptureDiagonally(board, isWhite, from, to)) {
+
+            // Note: Similar promotion check would be needed here for diagonal captures
+            // if ((isWhite && to.first == 7) || (!isWhite && to.first == 0)) {
+            //     // Promotion logic would go here
+            // }
+
+            return MOVE_SUCCESS;
+        }
+
+        // Note: En passant capture could be implemented here, but would require tracking the last move
+        // in the ChessBoard class and updating the Chess display to show the captured pawn is removed.
+        // if (canCaptureEnPassant(board, isWhite, from, to)) {
+        //     return MOVE_SUCCESS;
+        // }
+    }
+
+    return MOVE_INVALID_OR_BLOCKED;
+}
+
+//------------------------------------------------------------------------
+bool PawnMoveStrategy::canMoveForward(const ChessBoard& board,
+    bool isWhite,
+    const std::pair<int, int>& from,
+    const std::pair<int, int>& to) const {
+    int forwardDirection = isWhite ? 1 : -1;
+    int rowDiff = to.first - from.first;
+
+    // One square forward
+    if (rowDiff == forwardDirection && to.second == from.second &&
+        !board.isOccupied(to.first, to.second)) {
+        return true;
+    }
+    return false;
+}
+
+//------------------------------------------------------------------------
+bool PawnMoveStrategy::canMoveTwoSquares(const ChessBoard& board,
+    bool isWhite,
+    const std::pair<int, int>& from,
+    const std::pair<int, int>& to) const {
+    int forwardDirection = isWhite ? 1 : -1;
+    int rowDiff = to.first - from.first;
+
+    // Two squares from starting position
+    bool inStartPosition = (isWhite && from.first == 1) || (!isWhite && from.first == 6);
+
+    if (rowDiff == 2 * forwardDirection && to.second == from.second && inStartPosition) {
+        int midRow = from.first + forwardDirection;
+        return !board.isOccupied(midRow, from.second) &&
+            !board.isOccupied(to.first, to.second);
+    }
+    return false;
+}
+
+//------------------------------------------------------------------------
+bool PawnMoveStrategy::canCaptureDiagonally(const ChessBoard& board,
+    bool isWhite,
+    const std::pair<int, int>& from,
+    const std::pair<int, int>& to) const {
+    int forwardDirection = isWhite ? 1 : -1;
+    int rowDiff = to.first - from.first;
+
+    if (rowDiff == forwardDirection &&
+        std::abs(to.second - from.second) == 1 &&
+        board.isOccupied(to.first, to.second)) {
+
+        const ChessPiece* targetPiece = board.getPieceAt(to.first, to.second);
+        return targetPiece && targetPiece->getColor() != isWhite;
+    }
+    return false;
+}
+
+//------------------------------------------------------------------------
+/*
+Note: Implementations for future EnPassant and Promotion enhancements
+
+bool PawnMoveStrategy::canCaptureEnPassant(const ChessBoard& board, 
+                                        bool isWhite,
+                                        const std::pair<int, int>& from,
+                                        const std::pair<int, int>& to) const {
+    // Implementation for en passant would go here
+    // Would require access to the last move made
+    return false;
+}
+
+bool PawnMoveStrategy::isPromotionMove(bool isWhite, const std::pair<int, int>& to) const {
+    // Check if pawn reached the last rank
+    return (isWhite && to.first == 7) || (!isWhite && to.first == 0);
+}
+*/


### PR DESCRIPTION
This branch implement basic pawn movement in the chess game:
- Forward movement (one square)
- Initial two-square advance from starting position
- Diagonal capturing of opponent pieces

## Implementation Details
- Added PawnMoveStrategy class that inherits from MoveStrategy
- Integrated with PieceFactory to use the strategy for pawn pieces
- Added structure for future enhancements (promotion and en passant)
-Added documentation
