### PR TITLE
Ex2/refactor/board interface iboardstate

### DIFF
--- a/Chess/include/board/ChessBoard.h
+++ b/Chess/include/board/ChessBoard.h
@@ -3,10 +3,11 @@
 #include <string>
 #include <vector>
 #include <memory>
+#include "IBoardState.h"
 #include "pieces/ChessPiece.h"
 #include "GameConstants.h" 
 
-class ChessBoard {
+class ChessBoard : public IBoardState {
 public:
 
     ChessBoard(const std::string& boardStr);
@@ -27,6 +28,7 @@ public:
     int checkMovement(const std::pair<int, int>& from, const std::pair<int, int>& to, bool isWhiteTurn) const;
     void movePiece(const std::pair<int, int>& from, const std::pair<int, int>& to);
     void setupPieceAt(char pieceChar, const std::pair<int, int>& pos);
+    bool isValidPosition(int row, int col) const;
 
 private:
     std::vector<std::vector<std::unique_ptr<ChessPiece>>> m_board;

--- a/Chess/include/board/IBoardState.h
+++ b/Chess/include/board/IBoardState.h
@@ -1,0 +1,11 @@
+#pragma once
+
+class ChessPiece;
+
+class IBoardState {
+public:
+    virtual bool isOccupied(int row, int col) const = 0;
+    virtual const ChessPiece* getPieceAt(int row, int col) const = 0;
+    virtual bool isValidPosition(int row, int col) const = 0;
+    virtual ~IBoardState() = default;
+};

--- a/Chess/include/pieces/ChessPiece.h
+++ b/Chess/include/pieces/ChessPiece.h
@@ -3,10 +3,10 @@
 #include <utility> 
 #include <memory>
 #include <vector>
+#include "board/IBoardState.h"
+#include "move/Move.h"
 
-class ChessBoard;
 class MoveStrategy;
-class Move;
 
 class ChessPiece {
 public:
@@ -22,8 +22,8 @@ public:
     ChessPiece(ChessPiece&&) noexcept = default;
     ChessPiece& operator=(ChessPiece&&) noexcept = default;
     
-    int checkMovement(const ChessBoard& board, const std::pair<int, int>& newPos) const;
-    std::vector<Move> generateValidMoves(const ChessBoard& board) const;
+    int checkMovement(const IBoardState& board, const std::pair<int, int>& newPos) const;
+    std::vector<Move> generateValidMoves(const IBoardState& board) const;
     std::pair<int, int> getPosition() const;
     char getPieceType() const;
     bool getColor() const;

--- a/Chess/include/strategies/BishopMoveStrategy.h
+++ b/Chess/include/strategies/BishopMoveStrategy.h
@@ -4,11 +4,11 @@
 
 class BishopMoveStrategy : public MoveStrategy {
 public:
-    int checkMovement(const ChessBoard& board,
+    int checkMovement(const IBoardState& board,
         const std::pair<int, int>& from,
         const std::pair<int, int>& to) const override;
 
-    std::vector<Move> generateMoves(const ChessBoard& board,
+    std::vector<Move> generateMoves(const IBoardState& board,
         const std::pair<int, int>& from,
         bool isWhite,
         char pieceType) const override;

--- a/Chess/include/strategies/KingMoveStrategy.h
+++ b/Chess/include/strategies/KingMoveStrategy.h
@@ -3,10 +3,10 @@
 
 class KingMoveStrategy : public MoveStrategy {
 public:
-    int checkMovement(const ChessBoard& board,
+    int checkMovement(const IBoardState& board,
                       const std::pair<int, int>& from,
                       const std::pair<int, int>& to) const override;
-    std::vector<Move> generateMoves(const ChessBoard& board,
+    std::vector<Move> generateMoves(const IBoardState& board,
         const std::pair<int, int>& from,
         bool isWhite,
         char pieceType) const override;

--- a/Chess/include/strategies/KnightMoveStrategy.h
+++ b/Chess/include/strategies/KnightMoveStrategy.h
@@ -3,11 +3,11 @@
 
 class KnightMoveStrategy : public MoveStrategy {
 public:
-    int checkMovement(const ChessBoard& board,
+    int checkMovement(const IBoardState& board,
         const std::pair<int, int>& from,
         const std::pair<int, int>& to) const override;
     
-    std::vector<Move> generateMoves(const ChessBoard& board,
+    std::vector<Move> generateMoves(const IBoardState& board,
         const std::pair<int, int>& from,
         bool isWhite,
         char pieceType) const override;

--- a/Chess/include/strategies/MoveStrategy.h
+++ b/Chess/include/strategies/MoveStrategy.h
@@ -3,9 +3,10 @@
 #include "GameConstants.h"
 #include <utility>
 #include <vector>
+#include"board/IBoardState.h"
+#include "pieces/ChessPiece.h"
+#include "move/Move.h"
 
-class ChessBoard;
-class Move;
 
 class MoveStrategy {
 public:
@@ -13,18 +14,13 @@ public:
     virtual ~MoveStrategy() = default;
 
     // Movement validation method that all strategies must implement
-    virtual int checkMovement(const ChessBoard& board,
+    virtual int checkMovement(const IBoardState& board,
                               const std::pair<int, int>& from,
                               const std::pair<int, int>& to) const = 0;
 
     // Generate all valid moves for a piece at given position
-    virtual std::vector<Move> generateMoves(const ChessBoard& board,
+    virtual std::vector<Move> generateMoves(const IBoardState& board,
                                             const std::pair<int, int>& from,
                                             bool isWhite,
                                             char pieceType) const = 0;
-protected:
-    // Helper method to validate board positions
-    bool isValidPosition(int row, int col) const {
-        return (row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE);
-    }
 };

--- a/Chess/include/strategies/PawnMoveStrategy.h
+++ b/Chess/include/strategies/PawnMoveStrategy.h
@@ -5,37 +5,37 @@
 class PawnMoveStrategy : public MoveStrategy {
 
 public:
-    int checkMovement(const ChessBoard& board,
+    int checkMovement(const IBoardState& board,
                       const std::pair<int, int>& from,
                       const std::pair<int, int>& to) const override;
 
-    std::vector<Move> generateMoves(const ChessBoard& board,
+    std::vector<Move> generateMoves(const IBoardState& board,
         const std::pair<int, int>& from,
         bool isWhite,
         char pieceType) const override;
 
 private:
-    bool canMoveForward(const ChessBoard& board,
+    bool canMoveForward(const IBoardState& board,
                         bool isWhite,
                         const std::pair<int, int>& from,
                         const std::pair<int, int>& to) const;
 
-    bool canMoveTwoSquares(const ChessBoard& board,
+    bool canMoveTwoSquares(const IBoardState& board,
                            bool isWhite,
                            const std::pair<int, int>& from,
                            const std::pair<int, int>& to) const;
 
-    bool canCaptureDiagonally(const ChessBoard& board,
+    bool canCaptureDiagonally(const IBoardState& board,
                               bool isWhite,
                               const std::pair<int, int>& from,
                               const std::pair<int, int>& to) const;
 
-    void addForwardMoves(const ChessBoard& board,
+    void addForwardMoves(const IBoardState& board,
                          std::vector<Move>& validMoves,
                          const std::pair<int, int>& from,
                          int row, int col, int direction,
                          bool isWhite, char pieceType) const;
-    void addCaptureMoves(const ChessBoard& board,
+    void addCaptureMoves(const IBoardState& board,
                          std::vector<Move>& validMoves,
                          const std::pair<int, int>& from,
                          int row, int col, int direction,

--- a/Chess/include/strategies/QueenMoveStrategy.h
+++ b/Chess/include/strategies/QueenMoveStrategy.h
@@ -8,11 +8,11 @@ public:
     QueenMoveStrategy(std::shared_ptr<MoveStrategy> rookStrategy,
                       std::shared_ptr<MoveStrategy> bishopStrategy);
 
-    int checkMovement(const ChessBoard& board,
+    int checkMovement(const IBoardState& board,
                       const std::pair<int, int>& from,
                       const std::pair<int, int>& to) const override;
 
-    std::vector<Move> generateMoves(const ChessBoard& board,
+    std::vector<Move> generateMoves(const IBoardState& board,
                                     const std::pair<int, int>& from,
                                     bool isWhite,
                                     char pieceType) const override;

--- a/Chess/include/strategies/RookMoveStrategy.h
+++ b/Chess/include/strategies/RookMoveStrategy.h
@@ -4,11 +4,11 @@
 
 class RookMoveStrategy : public MoveStrategy {
 public:
-    int checkMovement(const ChessBoard& board,
+    int checkMovement(const IBoardState& board,
                       const std::pair<int, int>& from,
                       const std::pair<int, int>& to) const override;
 
-    std::vector<Move> generateMoves(const ChessBoard& board,
+    std::vector<Move> generateMoves(const IBoardState& board,
                                     const std::pair<int, int>& from,
                                     bool isWhite,
                                     char pieceType) const override;

--- a/Chess/src/board/ChessBoard.cpp
+++ b/Chess/src/board/ChessBoard.cpp
@@ -162,3 +162,8 @@ ChessBoard::ChessBoard(const ChessBoard& other) {
         }
     }
 }
+//------------------------------------------------------------------------
+bool ChessBoard::isValidPosition(int row, int col) const {
+
+    return (row >= 0 && row < BOARD_SIZE && col >= 0 && col < BOARD_SIZE);
+}

--- a/Chess/src/main.cpp
+++ b/Chess/src/main.cpp
@@ -9,8 +9,8 @@ int main()
 	Chess a(board);
 	GameManager gameManager(board);   //create the manger of the game
 
-	//gameManager.promptUserForRecommendationTurns();	
-	//gameManager.showRecommendations(); // Show move recommendations before each turn
+	gameManager.promptUserForRecommendationTurns();	
+	gameManager.showRecommendations(); // Show move recommendations before each turn
 
 	int codeResponse = 0;
 	string res = a.getInput();
@@ -38,7 +38,7 @@ int main()
 
 		a.setCodeResponse(codeResponse);
 		res = a.getInput(); 
-		//gameManager.showRecommendations();
+		gameManager.showRecommendations();
 	}
 
 	cout << endl << "Exiting " << endl; 

--- a/Chess/src/main.cpp
+++ b/Chess/src/main.cpp
@@ -9,8 +9,8 @@ int main()
 	Chess a(board);
 	GameManager gameManager(board);   //create the manger of the game
 
-	gameManager.promptUserForRecommendationTurns();	
-	gameManager.showRecommendations(); // Show move recommendations before each turn
+	//gameManager.promptUserForRecommendationTurns();	
+	//gameManager.showRecommendations(); // Show move recommendations before each turn
 
 	int codeResponse = 0;
 	string res = a.getInput();
@@ -38,7 +38,7 @@ int main()
 
 		a.setCodeResponse(codeResponse);
 		res = a.getInput(); 
-		gameManager.showRecommendations();
+		//gameManager.showRecommendations();
 	}
 
 	cout << endl << "Exiting " << endl; 

--- a/Chess/src/pieces/ChessPiece.cpp
+++ b/Chess/src/pieces/ChessPiece.cpp
@@ -1,9 +1,7 @@
 
 #include "pieces/ChessPiece.h"
-#include "board/ChessBoard.h"
 #include "factories/MoveStrategyFactory.h"
 #include "GameConstants.h"
-#include "move/Move.h"
 
 //------------------------------------------------------------------------
 /**
@@ -67,7 +65,7 @@ bool ChessPiece::getColor() const {
  * @param newPos  The position to move to.
  * @return MOVE_SUCCESS if the move is valid, otherwise MOVE_INVALID_OR_BLOCKED.
  */
-int ChessPiece::checkMovement(const ChessBoard& board, const std::pair<int, int>& newPos) const {
+int ChessPiece::checkMovement(const IBoardState& board, const std::pair<int, int>& newPos) const {
    
     if (!m_moveStrategy) {
         return MOVE_INVALID_OR_BLOCKED; // No strategy defined - fallback for any unexpected or malformed input
@@ -83,7 +81,7 @@ int ChessPiece::checkMovement(const ChessBoard& board, const std::pair<int, int>
  * @param board The current state of the chess board.
  * @return A vector of valid moves for this piece; empty if no strategy is defined.
  */
-std::vector<Move> ChessPiece::generateValidMoves(const ChessBoard& board) const {
+std::vector<Move> ChessPiece::generateValidMoves(const IBoardState& board) const {
    
     if (m_moveStrategy) {
         

--- a/Chess/src/strategies/BishopMoveStrategy.cpp
+++ b/Chess/src/strategies/BishopMoveStrategy.cpp
@@ -1,7 +1,5 @@
 
 #include "strategies/BishopMoveStrategy.h"
-#include "board/ChessBoard.h"
-#include "move/Move.h"
 
 //------------------------------------------------------------------------
 /**
@@ -12,7 +10,7 @@
  * @param to    Destination position.
  * @return MOVE_SUCCESS if valid, MOVE_INVALID_OR_BLOCKED otherwise.
  */
-int BishopMoveStrategy::checkMovement(const ChessBoard& board,
+int BishopMoveStrategy::checkMovement(const IBoardState& board,
                                       const std::pair<int, int>& from,
                                       const std::pair<int, int>& to) const {
 
@@ -62,7 +60,7 @@ int BishopMoveStrategy::checkMovement(const ChessBoard& board,
  * @param pieceType  The character representing the piece type (e.g., 'B' for Bishop).
  * @return A vector of valid moves including captures, excluding blocked paths.
  */
-std::vector<Move> BishopMoveStrategy::generateMoves(const ChessBoard& board,
+std::vector<Move> BishopMoveStrategy::generateMoves(const IBoardState& board,
                                                     const std::pair<int, int>& from,
                                                     bool isWhite,
                                                     char pieceType) const {
@@ -84,7 +82,7 @@ std::vector<Move> BishopMoveStrategy::generateMoves(const ChessBoard& board,
             int newCol = col + dCol * i;
 
             // Check if we're still on the board
-            if (!isValidPosition(newRow,newCol)){ //newRow < 0 || newRow >= 8 || newCol < 0 || newCol >= 8) {
+            if (!board.isValidPosition(newRow,newCol)){ //newRow < 0 || newRow >= 8 || newCol < 0 || newCol >= 8) {
                 break;
             }
 

--- a/Chess/src/strategies/KingMoveStrategy.cpp
+++ b/Chess/src/strategies/KingMoveStrategy.cpp
@@ -1,7 +1,5 @@
 
 #include "strategies/KingMoveStrategy.h"
-#include "board/ChessBoard.h"
-#include "move/Move.h"
 
 //------------------------------------------------------------------------
 /**
@@ -12,7 +10,7 @@
  * @param to    Target position.
  * @return MOVE_SUCCESS if valid, MOVE_INVALID_OR_BLOCKED otherwise.
  */
-int KingMoveStrategy::checkMovement(const ChessBoard& board,
+int KingMoveStrategy::checkMovement(const IBoardState& board,
                                     const std::pair<int, int>& from,
                                     const std::pair<int, int>& to) const {
 
@@ -68,7 +66,7 @@ int KingMoveStrategy::checkMovement(const ChessBoard& board,
  * @param pieceType  The character representing the piece type (e.g., 'K' for King).
  * @return A vector of valid moves including captures; excludes illegal positions and castling.
  */
-std::vector<Move> KingMoveStrategy::generateMoves(const ChessBoard& board,
+std::vector<Move> KingMoveStrategy::generateMoves(const IBoardState& board,
                                                   const std::pair<int, int>& from,
                                                   bool isWhite,
                                                   char pieceType) const {
@@ -90,7 +88,7 @@ std::vector<Move> KingMoveStrategy::generateMoves(const ChessBoard& board,
         int newCol = col + dir.second;
 
         // Check if the new position is on the board
-        if (isValidPosition(newRow,newCol)){
+        if (board.isValidPosition(newRow,newCol)){
 
             std::pair<int, int> to = { newRow, newCol };
 

--- a/Chess/src/strategies/KnightMoveStrategy.cpp
+++ b/Chess/src/strategies/KnightMoveStrategy.cpp
@@ -1,7 +1,5 @@
 
 #include "strategies/KnightMoveStrategy.h"
-#include "board/ChessBoard.h"
-#include "move/Move.h"
 
 //------------------------------------------------------------------------
 /**
@@ -12,7 +10,7 @@
  * @param to    Target position.
  * @return MOVE_SUCCESS if valid, MOVE_INVALID_OR_BLOCKED otherwise.
  */
-int KnightMoveStrategy::checkMovement(const ChessBoard& board,
+int KnightMoveStrategy::checkMovement(const IBoardState& board,
                                       const std::pair<int, int>& from,
                                       const std::pair<int, int>& to) const {
 
@@ -48,7 +46,7 @@ int KnightMoveStrategy::checkMovement(const ChessBoard& board,
  * @param pieceType  The character representing the piece type (e.g., 'N' for Knight).
  * @return A vector of valid moves including captures; excludes out-of-bounds positions.
  */
-std::vector<Move> KnightMoveStrategy::generateMoves(const ChessBoard& board,
+std::vector<Move> KnightMoveStrategy::generateMoves(const IBoardState& board,
                                                     const std::pair<int, int>& from,
                                                     bool isWhite,
                                                     char pieceType) const {
@@ -70,7 +68,7 @@ std::vector<Move> KnightMoveStrategy::generateMoves(const ChessBoard& board,
         int newCol = col + move.second ;
 
         // Check if the new position is on the board
-        if (isValidPosition(newRow,newCol)){
+        if (board.isValidPosition(newRow,newCol)){
 
             std::pair<int, int> to = { newRow, newCol };
 

--- a/Chess/src/strategies/PawnMoveStrategy.cpp
+++ b/Chess/src/strategies/PawnMoveStrategy.cpp
@@ -1,6 +1,4 @@
 #include "strategies/PawnMoveStrategy.h"
-#include "board/ChessBoard.h"
-#include "move/Move.h"
 #include <cstdlib> 
 
 
@@ -14,7 +12,7 @@
  * @param to    Target position to move to.
  * @return MOVE_SUCCESS if the move is valid, otherwise MOVE_INVALID_OR_BLOCKED.
  */
-int PawnMoveStrategy::checkMovement(const ChessBoard& board,
+int PawnMoveStrategy::checkMovement(const IBoardState& board,
                                     const std::pair<int, int>& from,
                                     const std::pair<int, int>& to) const {
     
@@ -78,7 +76,7 @@ int PawnMoveStrategy::checkMovement(const ChessBoard& board,
  * @param to         Target position.
  * @return true if move is valid.
  */
-bool PawnMoveStrategy::canMoveForward(const ChessBoard& board,
+bool PawnMoveStrategy::canMoveForward(const IBoardState& board,
                                       bool isWhite,
                                       const std::pair<int, int>& from,
                                       const std::pair<int, int>& to) const {
@@ -106,7 +104,7 @@ bool PawnMoveStrategy::canMoveForward(const ChessBoard& board,
  * @param to         Target position.
  * @return true if two-square move is valid.
  */
-bool PawnMoveStrategy::canMoveTwoSquares(const ChessBoard& board,
+bool PawnMoveStrategy::canMoveTwoSquares(const IBoardState& board,
                                          bool isWhite,
                                          const std::pair<int, int>& from,
                                          const std::pair<int, int>& to) const {
@@ -138,7 +136,7 @@ bool PawnMoveStrategy::canMoveTwoSquares(const ChessBoard& board,
  * @param to         Target capture position.
  * @return true if diagonal capture is allowed.
  */
-bool PawnMoveStrategy::canCaptureDiagonally(const ChessBoard& board,
+bool PawnMoveStrategy::canCaptureDiagonally(const IBoardState& board,
                                             bool isWhite,
                                             const std::pair<int, int>& from,
                                             const std::pair<int, int>& to) const {
@@ -167,7 +165,7 @@ bool PawnMoveStrategy::canCaptureDiagonally(const ChessBoard& board,
  * @param pieceType  The character representing the piece type (e.g., 'P' for Pawn).
  * @return A vector of valid moves including captures and double-step advances from the initial position.
  */
-std::vector<Move> PawnMoveStrategy::generateMoves(const ChessBoard& board,
+std::vector<Move> PawnMoveStrategy::generateMoves(const IBoardState& board,
                                                   const std::pair<int, int>& from,
                                                   bool isWhite,
                                                   char pieceType) const {
@@ -175,7 +173,7 @@ std::vector<Move> PawnMoveStrategy::generateMoves(const ChessBoard& board,
     std::vector<Move> validMoves;
 
     // Validate starting position
-    if (!isValidPosition(from.first, from.second)) {
+    if (!board.isValidPosition(from.first, from.second)) {
         std::cerr << "Invalid pawn position: (" << from.first << "," << from.second << ")" << std::endl;
         return validMoves;
     }
@@ -209,14 +207,14 @@ std::vector<Move> PawnMoveStrategy::generateMoves(const ChessBoard& board,
  * @param isWhite    Indicates whether the pawn is white.
  * @param pieceType  The character representing the pawn piece type (e.g., 'P').
  */
-void PawnMoveStrategy::addForwardMoves(const ChessBoard& board,
+void PawnMoveStrategy::addForwardMoves(const IBoardState& board,
                                        std::vector<Move>& validMoves,
                                        const std::pair<int, int>& from,
                                        int row, int col, int direction,
                                        bool isWhite, char pieceType) const {
     // Single step forward
     int newRow = row + direction;
-    if (!isValidPosition(newRow, col)) {
+    if (!board.isValidPosition(newRow, col)) {
         return;
     }
 
@@ -227,7 +225,7 @@ void PawnMoveStrategy::addForwardMoves(const ChessBoard& board,
         bool onStartingRank = (isWhite && row == 1) || (!isWhite && row == 6);
         int twoStepRow = row + (2 * direction);
 
-        if (onStartingRank && isValidPosition(twoStepRow, col) && !board.isOccupied(twoStepRow, col)) {
+        if (onStartingRank && board.isValidPosition(twoStepRow, col) && !board.isOccupied(twoStepRow, col)) {
             validMoves.emplace_back(from, std::make_pair(twoStepRow, col), 0, pieceType);
         }
     }
@@ -247,20 +245,20 @@ void PawnMoveStrategy::addForwardMoves(const ChessBoard& board,
  * @param isWhite    Indicates whether the pawn is white.
  * @param pieceType  The character representing the pawn piece type (e.g., 'P').
  */
-void PawnMoveStrategy::addCaptureMoves(const ChessBoard& board,
+void PawnMoveStrategy::addCaptureMoves(const IBoardState& board,
                                        std::vector<Move>& validMoves,
                                        const std::pair<int, int>& from,
                                        int row, int col, int direction,
                                        bool isWhite, char pieceType) const {
     
     int newRow = row + direction;
-    if (!isValidPosition(newRow, col)) {
+    if (!board.isValidPosition(newRow, col)) {
         return;
     }
 
     for (int colOffset : {-1, 1}) {
         int newCol = col + colOffset;
-        if (!isValidPosition(newRow, newCol)) {
+        if (!board.isValidPosition(newRow, newCol)) {
             continue;
         }
 

--- a/Chess/src/strategies/QueenMoveStrategy.cpp
+++ b/Chess/src/strategies/QueenMoveStrategy.cpp
@@ -1,7 +1,5 @@
 
 #include "strategies/QueenMoveStrategy.h"
-#include "board/ChessBoard.h"
-#include "move/Move.h"
 
 //------------------------------------------------------------------------
 /**
@@ -20,9 +18,9 @@ QueenMoveStrategy::QueenMoveStrategy(std::shared_ptr<MoveStrategy> rookStrategy,
  * @param to    Target position.
  * @return MOVE_SUCCESS if valid, MOVE_INVALID_OR_BLOCKED otherwise.
  */
-int QueenMoveStrategy::checkMovement(const ChessBoard& board,
-    const std::pair<int, int>& from,
-    const std::pair<int, int>& to) const {
+int QueenMoveStrategy::checkMovement(const IBoardState& board,
+                                     const std::pair<int, int>& from,
+                                     const std::pair<int, int>& to) const {
 
     // Try the rook movement (horizontal/vertical)
     int rookResult = m_rookStrategy->checkMovement(board, from, to);
@@ -46,7 +44,7 @@ int QueenMoveStrategy::checkMovement(const ChessBoard& board,
  * @param pieceType  The character representing the piece type (e.g., 'Q' for Queen).
  * @return A vector of valid moves including captures; combines rook and bishop moves.
  */
-std::vector<Move> QueenMoveStrategy::generateMoves(const ChessBoard& board,
+std::vector<Move> QueenMoveStrategy::generateMoves(const IBoardState& board,
                                                    const std::pair<int, int>& from,
                                                    bool isWhite,
                                                    char pieceType) const {

--- a/Chess/src/strategies/RookMoveStrategy.cpp
+++ b/Chess/src/strategies/RookMoveStrategy.cpp
@@ -1,7 +1,5 @@
 
 #include "strategies/RookMoveStrategy.h"
-#include "board/ChessBoard.h"
-#include "move/Move.h"
 
 //------------------------------------------------------------------------
 /**
@@ -12,7 +10,7 @@
  * @param to    Target position.
  * @return MOVE_SUCCESS if valid, MOVE_INVALID_OR_BLOCKED otherwise.
  */
-int RookMoveStrategy::checkMovement(const ChessBoard& board, 
+int RookMoveStrategy::checkMovement(const IBoardState& board,
 	                                const std::pair<int, int>& from, 
 	                                const std::pair<int, int>& to) const {
 
@@ -67,7 +65,7 @@ int RookMoveStrategy::checkMovement(const ChessBoard& board,
  * @param pieceType  The character representing the piece type (e.g., 'R' for Rook).
  * @return A vector of valid moves including captures; excludes blocked paths and out-of-bounds positions.
  */
-std::vector<Move> RookMoveStrategy::generateMoves(const ChessBoard& board,
+std::vector<Move> RookMoveStrategy::generateMoves(const IBoardState& board,
                                                   const std::pair<int, int>& from,
                                                   bool isWhite,
                                                   char pieceType) const{
@@ -90,7 +88,7 @@ std::vector<Move> RookMoveStrategy::generateMoves(const ChessBoard& board,
             int newCol = col + dCol * i;
 
             // Check if new position is on the board
-            if (!isValidPosition(newRow,newCol)){
+            if (!board.isValidPosition(newRow,newCol)){
                 break;
             }
 


### PR DESCRIPTION
In this branch i created IBoardState interface to decouple core logic (ChessPiece, MoveStrategy, etc.) from the full ChessBoard implementation.
This improves design by exposing only the necessary methods instead of the entire class, making the code cleaner, easier to test, and more maintainable.

Changes:
Added IBoardState interface
Made ChessBoard implement IBoardState
Updated logic components to use IBoardState& instead of ChessBoard&